### PR TITLE
Add .dir-locals, PR template, skeleton Makefile, and skeleton .gitignore

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,38 @@
+;;; -*- lexical-binding: t; -*-
+;;; .dir-locals.el ---
+
+;; Copyright (C) 2019  Zach Pearson
+
+;; Author: Zach Pearson <zach@zjp.codes>
+;; Keywords:
+
+;; This file is not part of GNU Emacs.
+
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Forces Emacs to adhere to the project's coding style, regardless of personal
+;; init preferences.
+
+;;; Code:
+
+((c++-mode . ((indent-tabs-mode . t)
+              (tab-width . 4)
+              (eval . (if (package-installed-p 'smart-tabs-mode)
+                          (smart-tabs-mode 1))))))
+
+
+(provide '.dir-locals)
+;;; .dir-locals.el ends here

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+<!-- Please make your title descriptive but short. -->
+<!-- You can ignore this template, but it may be helpful to use it. -->
+## Description
+
+## Checklist
+- [] With only the changes in this PR my code compiles.
+- [] I have tested my code as best I can.
+- [] I have updated any documentation related to my changes.

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# -*- mode: gitignore; -*-
+
+# Object Files
+*.o
+
+# Emacs autosave files
+*~
+\#*\#
+
+# Org and Flycheck files
+*.org
+flycheck*.elc

--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,9 @@ CXX := g++
 # You probably don't want to change these all by hand. Changing this is even
 # quicker than using sed, Vi, or C-M-%. The shell command expands to flags that
 # GTK+ requires to compile.
-CFLAGS := -std=c++11 -Wall -g
-LDFLAGS := $(CFLAGS) -c
+GENFLAGS := -std=c++11 -Wall -g
+CFLAGS := -$(GENFLAGS)
+LDFLAGS := $(GENFLAGS) -c -I ./$(INCDIR)
 # The $@ refers to the target. There's no reason to write it twice.
 # Recursively expands to target name of any rule that uses the variable.
 EXPORT = -o $@

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,84 @@
+# Project: EECS 448 Project 1 - Battleship
+# Date:    06 September 2019
+
+# -- General notes about Makefiles --
+# Documentation:
+# https://www.gnu.org/software/make/manual/html_node/index.html#SEC_Contents
+#
+# Highlights:
+# Variables in Makefiles work like C preprocessor directives: text-based
+# substitution. The names are case sensitive and cannot contain :, #, =, or
+# whitespace.
+#
+# There are four ways to assign a variable: =, :=, ::=, and ?= but
+# := and ::= are equivalent to one another. Of the two only ::= is
+# POSIXLY_CORRECT.
+#
+# = recursively expands the variable if the definition includes other variables
+#     every time the variable is substituted (used)
+# := is a simply expanded variable. Its value is scanned once and any expansions
+#     happen at the time of assignment.
+# ?= assigns a variable if it has not yet been assigned. Be aware that an empty
+#     value is still an assignment.
+
+# --- Program Name ---
+FILENAME := BattleShip
+
+# --- Include Dirs ---
+SRCDIR := src
+INCDIR := inc
+OBJDIR := obj
+
+# --- Debugging ---
+MT := valgrind
+MFLAGS := --leak-check=full --show-leak-kinds=all --track-origins=yes
+
+# --- Compiling ---
+# CXX is typically an environment variable, but just in case it happens to be
+# clang, we'll enforce g++
+CXX := g++
+# You probably don't want to change these all by hand. Changing this is even
+# quicker than using sed, Vi, or C-M-%. The shell command expands to flags that
+# GTK+ requires to compile.
+CFLAGS := -std=c++11 -Wall -g
+LDFLAGS := $(CFLAGS) -c
+# The $@ refers to the target. There's no reason to write it twice.
+# Recursively expands to target name of any rule that uses the variable.
+EXPORT = -o $@
+DEPENDENCIES := $(OBJDIR)/main.o
+
+# --- Phonies ---
+# Phonies essentially declare a target as being unrelated to actual files in
+# the project directory, and allow you to make files with the same name as
+# such a target without worrying about aliasing commands.
+.PHONY: clean rebuild memcheck debug $(SRCDIR) $(INCDIR) $(OBJDIR)
+
+# --- Compilation Options ---
+# By convention 'all' compiles the entire program.
+all: $(DEPENDENCIES)
+	$(CXX) $(CFLAGS) $(DEPENDENCIES) -o $(FILENAME)
+
+# install: all
+# By definition this should place the executable in a standard location, either
+# in /usr/bin or /usr/local/bin
+
+# --- Source Files ---
+$(OBJDIR)/main.o: $(SRCDIR)/main.cpp
+	$(CXX) $(LDFLAGS) $(SRCDIR)/main.cpp $(EXPORT)
+
+
+# --- Housekeeping ---
+# Clear out all the cobwebs and recompile everything.
+rebuild: clean all
+
+# Removes object files as well as any Emacs autosave files. "| true" (or true)
+# causes rebuild to work even if there's nothing to clean. 2&>1 is a shell
+# script idiom for I/O redirection. Basically, any output that would go to
+# stderr (2) is redirected (>&) to stdout (1). It lets us see when rm can't find
+# anything to remove. By the way, keyboard input comes through channel
+# 0 (stdin)!
+clean:
+	rm $(OBJDIR)/*.o *.*~ \#*\# | true 2>&1
+
+memcheck:
+	$(MT) $(MFLAGS) ./$(FILENAME)


### PR DESCRIPTION
This PR adds:

- A file to instruct Emacs to adhere to a common indentation standard regardless of the user's prior configurations. May be changed later to an editorconfig file, which does the same thing but for every editor. 
- A PR template, to keep PRs organized, concise, and to the point. 
- A gitignore, to keep unnecessary files out of Git tracking 
- A templated Makefile, to make adding new dependencies easy. 

Let me know what you think. 